### PR TITLE
Update cayenne-guide.html use Apache Cayenne in title

### DIFF
--- a/src/main/site/content/docs/4.2/cayenne-guide.html
+++ b/src/main/site/content/docs/4.2/cayenne-guide.html
@@ -16,8 +16,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-title: "Cayenne Guide"
-description: "Cayenne Guide"
+title: "Apache Cayenne Guide"
+description: "Apache Cayenne Guide"
 cayenneVersion: "4.2"
 weight: 20
 menu:


### PR DESCRIPTION
The ASF pattern is to use the proper name of the product (Apache Whatever) in the title of the documentation and at least the first use of the product name in the text. Once you have established the proper name, I think it is okay to just use Cayenne in the bulk of the documentation.