### PR TITLE
fix: Add required ASF policy links to footer

### DIFF
--- a/src/main/site/layouts/partials/footer.html
+++ b/src/main/site/layouts/partials/footer.html
@@ -32,9 +32,17 @@
         </div>
         <hr class="mt-0 mb-3" />
         <p class="copy xsmall text-center  mw-75 mx-auto mb-0">
-            Copyright © 2001-{{ now.Year }} Apache Software Foundation. Apache Cayenne, Cayenne, Apache, the Apache feather logo, and the Apache Cayenne project logo are trademarks of The Apache Software Foundation.
+            Copyright © 2001-{{ now.Year }} Apache Software Foundation. Apache Cayenne, Cayenne, Apache, the Apache logo, and the Apache Cayenne project logo are trademarks of The Apache Software Foundation.
             <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy policy</a>.
             <img class="d-block  mx-auto mt-2" src="/img/logo_mono.svg" alt="Apache Cayenne" />
+        </p>
+        <p class="copy xsmall text-center mx-auto">
+            <a href="https://www.apache.org/">Foundation</a> |
+            <a href="https://www.apache.org/events/current-event.html">Events</a> |
+            <a href="https://www.apache.org/licenses/">License</a> |
+            <a href="https://www.apache.org/security/">Security</a> |
+            <a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> |
+            <a href="https://www.apache.org/foundation/thanks.html">Thanks</a>
         </p>
     </div>
 </footer>


### PR DESCRIPTION
Adds Foundation, Events, License, Security, Sponsorship, Thanks, and Privacy links per ASF website policy. Updates trademark text where needed.

Checker: https://whimsy.apache.org/site/